### PR TITLE
Updated installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 
 Installation using pip is simple:
 
-    $ pip install django-nexmo
+    $ pip install django-nexmo==2.0.0a1
 
 Add the `nexmo` app to your installed applications:
 
@@ -54,7 +54,7 @@ The `djexmo` apps gives you access to a shortcut to send text messages easily.
 
 ```python
 from djexmo import send_message
-send_message(frm='+33123456789', to='+33612345678', message='My sms message body')
+send_message(frm='+33123456789', to='+33612345678', text='My sms message body')
 ```
 
 The `frm` parameter can be omited. In that case, the `NEXMO_FROM` configuration
@@ -62,7 +62,7 @@ field will be used instead.
 
 ```python
 from djexmo import send_message
-send_message(to='+33612345678', message='My sms message body')
+send_message(to='+33612345678', text='My sms message body')
 ```
 
 Advanced usage


### PR DESCRIPTION
- installing via `pip install django-nexmo` installs the older version 1. You need to explicitly indicate version 2.0.0alpha1 if you wanna install the latest version (version 2 at the time of writing this).
- the `message` keyword argument throws a `TypeError` exception. The correct argument should be `text`.